### PR TITLE
Allow className prop

### DIFF
--- a/src/HolyProgress.ts
+++ b/src/HolyProgress.ts
@@ -48,6 +48,12 @@ type HolyProgressProps = {
    * Default: false
    */
   showSpinner?: boolean;
+
+  /**
+   * Specifies the class attribute value.
+   * Default: undefined
+   */
+  className?: string;
 };
 
 type TransformStrategy = 'translate3d' | 'translate' | 'margin';
@@ -78,6 +84,7 @@ export class HolyProgress {
       zIndex: 2147483647,
       boxShadow: undefined,
       showSpinner: false,
+      className: undefined,
     };
 
     this.settings = { ...defaultSettings, ...customSettings };
@@ -320,6 +327,11 @@ export class HolyProgress {
     this.bar.style.transform = 'translate3d(' + percentage + '%,0,0)';
     this.bar.style.boxShadow = this.settings.boxShadow ?? '';
 
+    if (this.settings.className) {
+      this.bar.className = this.settings.className;
+      this.bar.style.removeProperty('background');
+    }
+    
     document.body.appendChild(progress);
 
     return progress;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,4 +6,5 @@ export const DEFAULTS = {
   speed: 200,
   zIndex: 2147483647,
   showSpinner: false,
+  className: undefined,
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -52,6 +52,12 @@ export interface HolyLoaderProps {
    * Default: false
    */
   showSpinner?: boolean;
+
+  /**
+   * Specifies the class attribute value.
+   * Default: undefined
+   */
+  className?: string;
 }
 
 /**
@@ -112,6 +118,7 @@ const HolyLoader = ({
   zIndex = DEFAULTS.zIndex,
   boxShadow,
   showSpinner = DEFAULTS.showSpinner,
+  className = DEFAULTS.className,
 }: HolyLoaderProps): null => {
   React.useEffect(() => {
     let holyProgress: HolyProgress;
@@ -189,6 +196,7 @@ const HolyLoader = ({
         zIndex,
         boxShadow,
         showSpinner,
+        className,
       });
 
       document.addEventListener('click', handleClick);


### PR DESCRIPTION
# Description

It's a proposition and shouldn't be merged, yet.

This change allows to use `className` property on `HolyLoader` component, for example:

```jsx
<HolyLoader className="bg-red-400" />
````

What means this? Mainly that it's more customizable, but also that works properly with tailwindcss (which is important to me).

Why it's a breaking change? Because if I use a className like `bg-red-400`, it's overrided by the style prop background (because of css specificity), so I wrote this:

```javascript
if (this.settings.className) {
  // Next line includes the class attribute
  this.bar.className = this.settings.className;
  // Next line removes background from style in order to not override the className
  this.bar.style.removeProperty('background');
}
```

What should be the correct behavior?

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass with my changes
