### PR TITLE
refactor: use default settings for HolyLoaderProps and HolyProgressProps everywhere

### DIFF
--- a/src/HolyProgress.ts
+++ b/src/HolyProgress.ts
@@ -70,14 +70,14 @@ export class HolyProgress {
    */
   constructor(customSettings?: Partial<HolyProgressProps>) {
     const defaultSettings: HolyProgressProps = {
-      initialPosition: 0.08,
-      easing: 'linear',
-      speed: 200,
+      initialPosition: DEFAULTS.initialPosition,
+      easing: DEFAULTS.easing,
+      speed: DEFAULTS.speed,
       color: DEFAULTS.color,
-      height: 4,
-      zIndex: 2147483647,
-      boxShadow: undefined,
-      showSpinner: false,
+      height: DEFAULTS.height,
+      zIndex: DEFAULTS.zIndex,
+      boxShadow: DEFAULTS.boxShadow,
+      showSpinner: DEFAULTS.showSpinner,
     };
 
     this.settings = { ...defaultSettings, ...customSettings };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,4 +6,5 @@ export const DEFAULTS = {
   speed: 200,
   zIndex: 2147483647,
   showSpinner: false,
+  boxShadow: undefined,
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -110,7 +110,7 @@ const HolyLoader = ({
   easing = DEFAULTS.easing,
   speed = DEFAULTS.speed,
   zIndex = DEFAULTS.zIndex,
-  boxShadow,
+  boxShadow = DEFAULTS.boxShadow,
   showSpinner = DEFAULTS.showSpinner,
 }: HolyLoaderProps): null => {
   React.useEffect(() => {


### PR DESCRIPTION
The default settings for HolyLoaderProps and HolyProgressProps have been updated to use the DEFAULTS constant for initialPosition, easing, speed, color, height, zIndex, boxShadow, and showSpinner. This ensures consistency.