### PR TITLE
Ignore anchors with download attribute set (resolves #31)

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -195,6 +195,7 @@ const HolyLoader = ({
         if (
           anchor === null ||
           anchor.target === '_blank' ||
+          anchor.hasAttribute('download') ||
           event.ctrlKey ||
           event.metaKey ||
           // Skip if URL points to a different domain


### PR DESCRIPTION
# Description

This PR resolved #31 

# Testing

Did we want to add tests for this?
There isn't a specific one for existing anchor checks like `_blank`.

# Note

There were currently lint differences between the `main` branch. I did not run `lint` to avoid this PR having unrelated changes.
Might be a good idea to lint before cutting next version.