### PR TITLE
fix(package): CommonJS compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "files": [
     "dist/**/*.js*",
+    "dist/**/*.cjs*",
     "dist/**/*.mjs*",
     "dist/**/*.d*"
   ],


### PR DESCRIPTION
# Description
The published npm package is missing the `.cjs` files required for CommonJS compatibility.

I encountered this problem when my Jest resolver failed with the error: `Cannot find module 'holy-loader'`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code