### PR TITLE
Add skipReplaceTransitions prop to HolyLoader

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,4 @@ onClick={(e) => {
 | `showSpinner`        | `boolean`            | Determines whether to accompany the loading bar with a spinner. Turned off by default.                       | `false`      |
 | `ignoreSearchParams` | `boolean`            | Determines whether to ignore search parameters in the URL when triggering the loader. Turned off by default. | `false`      |
 | `dir`                | `ltr` or `rtl`       | Sets the direction of the top-loading bar.                                                                   | `ltr`      |
+| `skipReplaceTransitions` | `boolean`        | Specifies whether to skip the loader for replaceState transitions.                                           | `false`      |

--- a/src/__tests__/holyLoader.test.ts
+++ b/src/__tests__/holyLoader.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+import { HolyLoaderProps } from '../index';
+import HolyLoader from '../index';
+
+describe('HolyLoader', () => {
+  it('should skip loader for replaceState transitions when skipReplaceTransitions is true', () => {
+    const props: HolyLoaderProps = {
+      skipReplaceTransitions: true,
+    };
+
+    const holyLoader = new HolyLoader(props);
+
+    const startSpy = vi.spyOn(holyLoader, 'start');
+    const completeSpy = vi.spyOn(holyLoader, 'complete');
+
+    history.replaceState({}, '', '/new-url');
+    expect(startSpy).not.toHaveBeenCalled();
+    expect(completeSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not skip loader for replaceState transitions when skipReplaceTransitions is false', () => {
+    const props: HolyLoaderProps = {
+      skipReplaceTransitions: false,
+    };
+
+    const holyLoader = new HolyLoader(props);
+
+    const startSpy = vi.spyOn(holyLoader, 'start');
+    const completeSpy = vi.spyOn(holyLoader, 'complete');
+
+    history.replaceState({}, '', '/new-url');
+    expect(startSpy).toHaveBeenCalled();
+    expect(completeSpy).toHaveBeenCalled();
+  });
+});

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -72,6 +72,12 @@ export interface HolyLoaderProps {
    * Default: "ltr"
    */
   dir?: 'ltr' | 'rtl';
+
+  /**
+   * Specifies whether to skip the loader for replaceState transitions.
+   * Default: false
+   */
+  skipReplaceTransitions?: boolean;
 }
 
 /**
@@ -104,7 +110,8 @@ const HolyLoader = ({
   boxShadow = DEFAULTS.boxShadow,
   showSpinner = DEFAULTS.showSpinner,
   ignoreSearchParams = DEFAULTS.ignoreSearchParams,
-  dir = DEFAULTS.dir, 
+  dir = DEFAULTS.dir,
+  skipReplaceTransitions = false,
 }: HolyLoaderProps): null => {
   const holyProgressRef = React.useRef<HolyProgress | null>(null);
 
@@ -166,10 +173,11 @@ const HolyLoader = ({
       history.replaceState = (...args) => {
         const url = args[2];
         if (
-          url &&
-          isSamePathname(window.location.href, url) &&
-          (ignoreSearchParams ||
-            hasSameQueryParameters(window.location.href, url))
+          skipReplaceTransitions ||
+          (url &&
+            isSamePathname(window.location.href, url) &&
+            (ignoreSearchParams ||
+              hasSameQueryParameters(window.location.href, url)))
         ) {
           originalReplaceState(...args);
           return;


### PR DESCRIPTION
Fixes #23

Add `skipReplaceTransitions` prop to `HolyLoader` component to skip loader for `replaceState` transitions.

* **src/index.tsx**
  - Add `skipReplaceTransitions` prop to `HolyLoaderProps` interface.
  - Update `HolyLoader` component to handle `skipReplaceTransitions` prop.
  - Skip loader for `replaceState` transitions when `skipReplaceTransitions` is true.
* **README.md**
  - Add `skipReplaceTransitions` prop to the API section.
* **src/__tests__/holyLoader.test.ts**
  - Add tests to verify the behavior of `skipReplaceTransitions` prop.

